### PR TITLE
Validate cocktail patch fields and add tests

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -427,13 +427,26 @@ export async function registerRoutes(app: Express, storage: IStorage): Promise<S
       // Only include the fields being updated, preserve existing fields like popularityCount
       const transformedData: any = {};
       
-      // Copy basic fields from request body, excluding special fields
-      const basicFields = ['name', 'description', 'isFeatured'];
-      for (const field of basicFields) {
-        if (req.body.hasOwnProperty(field)) {
-          transformedData[field] = req.body[field];
-        }
+      // Validate and copy basic fields from request body, excluding special fields
+      const allowedFields = [
+        'name',
+        'description',
+        'isFeatured',
+        'ingredients',
+        'instructions',
+        'tags',
+        'image'
+      ];
+      const unexpectedFields = Object.keys(req.body).filter(
+        key => !allowedFields.includes(key)
+      );
+      if (unexpectedFields.length > 0) {
+        console.warn('Ignoring unexpected fields in cocktail PATCH:', unexpectedFields);
       }
+
+      if (req.body.name !== undefined) transformedData.name = req.body.name;
+      if (req.body.description !== undefined) transformedData.description = req.body.description;
+      if (req.body.isFeatured !== undefined) transformedData.isFeatured = req.body.isFeatured;
       
       if (req.body.ingredients && Array.isArray(req.body.ingredients)) {
         console.log('Transforming ingredients for PATCH...');

--- a/tests/unit/patch-cocktail-unexpected-keys.test.ts
+++ b/tests/unit/patch-cocktail-unexpected-keys.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+
+vi.mock('../../server/middleware/auth', () => ({
+  createAuthMiddleware: () => ({
+    requireAuth: (req: any, _res: any, next: any) => {
+      req.user = { id: 1, role: 'admin' };
+      next();
+    },
+    requireAdmin: (req: any, _res: any, next: any) => {
+      req.user = { id: 1, role: 'admin' };
+      next();
+    }
+  })
+}));
+
+vi.mock('../../server/middleware/roles', () => ({
+  allowRoles: () => (_req: any, _res: any, next: any) => next(),
+  rejectWritesForReviewer: (_req: any, _res: any, next: any) => next()
+}));
+
+describe('PATCH /api/cocktails/:id', () => {
+  it('ignores unexpected keys in request body', async () => {
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.REFRESH_SECRET = 'test-refresh';
+
+    const { registerRoutes } = await import('../../server/routes');
+
+    const app = express();
+    app.use(express.json());
+
+    const storage = {
+      getCocktail: vi.fn().mockResolvedValue({ id: 1 }),
+      updateCocktail: vi.fn().mockResolvedValue({ id: 1 })
+    } as any;
+
+    const server = await registerRoutes(app as any, storage);
+    await new Promise(resolve => server.listen(0, resolve));
+    const address: any = server.address();
+    const port = typeof address === 'object' ? address.port : address;
+
+    const res = await fetch(`http://localhost:${port}/api/cocktails/1`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated', unexpected: 'value' })
+    });
+    await res.json();
+
+    expect(storage.updateCocktail).toHaveBeenCalledWith(1, { name: 'Updated' });
+
+    await new Promise(resolve => server.close(resolve));
+  });
+});


### PR DESCRIPTION
## Summary
- Validate incoming cocktail PATCH data against an allowed field list
- Replace generic field copy with explicit assignments for name, description, and isFeatured
- Add unit test to ensure unexpected fields are ignored

## Testing
- `npm test tests/unit/patch-cocktail-unexpected-keys.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3e4348f5083309312d4eaf13daddc