### PR TITLE
refactor: refine preferred brands query key

### DIFF
--- a/client/src/pages/MyBar.tsx
+++ b/client/src/pages/MyBar.tsx
@@ -22,12 +22,14 @@ import noPhotoImage from "@assets/no-photo_1753579606993.png";
 // Define brand type categories based on common spirits and mixers
 const BRAND_CATEGORIES = [
   "spirits",
-  "liqueurs", 
+  "liqueurs",
   "mixers",
   "bitters",
   "syrups",
-  "other"
+  "other",
 ] as const;
+
+const preferredBrandsQueryKey = ["/api/preferred-brands", { inMyBar: true }] as const;
 
 export default function MyBar() {
   const { user } = useAuth();
@@ -37,36 +39,9 @@ export default function MyBar() {
   
   const isLoggedIn = !!user;
   const debounced = useDebounce(term, 300);
-  
+
   // Check if category filters are active (not search)
   const hasCategoryFilters = Boolean(selectedCategory);
-
-  // Show login message for non-logged-in users
-  if (!isLoggedIn) {
-    return (
-      <div className="min-h-screen bg-[#171712] pb-20 md:pb-0">
-        <TopNavigation />
-        <div className="px-4 md:px-40 py-5">
-          <div className="p-4 mb-3">
-            <h1 className="text-[32px] font-bold text-white mb-3 [font-family:'Plus_Jakarta_Sans',Helvetica]">
-              My Bar
-            </h1>
-            <div className="text-center py-12">
-              <p className="text-[#bab59c] text-lg mb-4">
-                Please login to see or manage your bar.
-              </p>
-              <Link href="/login">
-                <Button className="bg-[#f2c40c] text-[#161611] hover:bg-[#e0b40a] font-semibold">
-                  Login to Continue
-                </Button>
-              </Link>
-            </div>
-          </div>
-        </div>
-        <Navigation />
-      </div>
-    );
-  }
 
   // Handle URL state synchronization
   useEffect(() => {
@@ -87,7 +62,7 @@ export default function MyBar() {
 
   // Fetch all preferred brands with inMyBar filter
   const { data: allMyBarItems = [], isLoading, error } = useQuery({
-    queryKey: ["/api/preferred-brands", { inMyBar: true }],
+    queryKey: preferredBrandsQueryKey,
     queryFn: async () => {
       try {
         const params = new URLSearchParams();
@@ -105,6 +80,7 @@ export default function MyBar() {
     },
     retry: 2,
     staleTime: 5 * 60 * 1000, // 5 minutes
+    enabled: isLoggedIn,
   });
 
   // Helper function to categorize brands based on name patterns
@@ -176,7 +152,7 @@ export default function MyBar() {
       return apiRequest(`/api/preferred-brands/${brandId}/toggle-mybar`, { method: "PATCH" });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/preferred-brands"] });
+      queryClient.invalidateQueries({ queryKey: preferredBrandsQueryKey });
     },
   });
 
@@ -187,6 +163,33 @@ export default function MyBar() {
       console.error("Error toggling My Bar:", error);
     }
   };
+
+  // Show login message for non-logged-in users
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen bg-[#171712] pb-20 md:pb-0">
+        <TopNavigation />
+        <div className="px-4 md:px-40 py-5">
+          <div className="p-4 mb-3">
+            <h1 className="text-[32px] font-bold text-white mb-3 [font-family:'Plus_Jakarta_Sans',Helvetica]">
+              My Bar
+            </h1>
+            <div className="text-center py-12">
+              <p className="text-[#bab59c] text-lg mb-4">
+                Please login to see or manage your bar.
+              </p>
+              <Link href="/login">
+                <Button className="bg-[#f2c40c] text-[#161611] hover:bg-[#e0b40a] font-semibold">
+                  Login to Continue
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+        <Navigation />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/client/src/pages/PreferredBrands.tsx
+++ b/client/src/pages/PreferredBrands.tsx
@@ -18,6 +18,8 @@ import { useDebounce } from "@/lib/useDebounce";
 import { setQueryParamReplace, getQueryParam } from "@/lib/url";
 import noPhotoImage from "@assets/no-photo_1753579606993.png";
 
+const preferredBrandsQueryKey = ["/api/preferred-brands", { inMyBar: true }] as const;
+
 export default function PreferredBrands() {
   const { user } = useAuth();
   const [term, setTerm] = useState(() => getQueryParam("search") || "");
@@ -74,6 +76,7 @@ export default function PreferredBrands() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/preferred-brands"] });
+      queryClient.invalidateQueries({ queryKey: preferredBrandsQueryKey });
     },
   });
 


### PR DESCRIPTION
## Summary
- use a stable preferred brands query key that includes the `{ inMyBar: true }` filter
- invalidate that exact key after toggling My Bar state
- gate My Bar fetching behind authentication

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: could not resolve dependencies)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for nanoid)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f4c67b7c8330a5a4c5451540c2e0