### PR TITLE
feat: handle recipe headings with descriptions

### DIFF
--- a/tests/unit/mixi-chat-formatting.test.tsx
+++ b/tests/unit/mixi-chat-formatting.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { renderAssistantMessage } from '../../client/src/components/MixiChat';
+
+const stubRenderSafeInline = (s: string) => <>{s}</>;
+
+describe('MixiChat formatting', () => {
+  it('renders separate instruction lists starting at 1 for each recipe', () => {
+    const response = `Margarita - Classic tequila cocktail\nIngredients:\n- 2 oz tequila\n- 1 oz lime juice\nInstructions:\n1. Combine ingredients.\n2. Shake with ice.\n\nOld Fashioned - Whiskey drink\nIngredients:\n- 2 oz bourbon\nInstructions:\n1. Stir with ice.\n2. Strain into glass.`;
+
+    const { container } = render(<>{renderAssistantMessage(response, stubRenderSafeInline)}</>);
+    const lists = container.querySelectorAll('ol');
+    expect(lists.length).toBe(2);
+    lists.forEach(list => {
+      const ol = list as HTMLOListElement;
+      expect(ol.start).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- split hyphenated recipe headings into title and description blocks
- reset numbering and include optional descriptions when rendering recipes
- test formatting of multiple recipes to ensure instruction lists restart at 1

## Testing
- `npm test tests/unit/mixi-chat-formatting.test.tsx` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68b65ed997908330b338d5c35c348ea8