### PR TITLE
feat: add bar spoon measurement for cocktail ingredients

### DIFF
--- a/client/src/pages/AddCocktail.tsx
+++ b/client/src/pages/AddCocktail.tsx
@@ -503,6 +503,7 @@ export const AddCocktail = (): JSX.Element => {
                         <SelectItem value="ml" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">ml</SelectItem>
                         <SelectItem value="cl" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">cl</SelectItem>
                         <SelectItem value="tsp" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">tsp</SelectItem>
+                        <SelectItem value="barspoon" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">bar spoon</SelectItem>
                         <SelectItem value="tbsp" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">tbsp</SelectItem>
                         <SelectItem value="cup" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">cup</SelectItem>
                         <SelectItem value="pint" className="text-white hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white">pint</SelectItem>

--- a/client/src/pages/ImportCocktail.tsx
+++ b/client/src/pages/ImportCocktail.tsx
@@ -56,7 +56,7 @@ type ImportFormData = z.infer<typeof importFormSchema>;
 
 // Standard measurement units for cocktail ingredients
 const measurementUnits = [
-  "oz", "ml", "cl", "tsp", "tbsp", "cup", "pint", "qt", "gal", "L",
+  "oz", "ml", "cl", "tsp", "barspoon", "tbsp", "cup", "pint", "qt", "gal", "L",
   "dash", "splash", "part", "parts", "drop", "drops", "pinch", "slice", "slices",
   "wedge", "wedges", "sprig", "sprigs", "leaf", "leaves", "piece", "pieces"
 ];
@@ -731,12 +731,12 @@ SAMPLE RECIPE
                                       </SelectTrigger>
                                       <SelectContent className="bg-[#383629] border-[#544f3b] max-h-48">
                                         {measurementUnits.map((unit) => (
-                                          <SelectItem 
-                                            key={unit} 
+                                          <SelectItem
+                                            key={unit}
                                             value={unit}
                                             className="text-white text-xs hover:bg-[#4a4735] focus:bg-[#4a4735] data-[highlighted]:bg-[#4a4735] data-[highlighted]:text-white"
                                           >
-                                            {unit}
+                                            {unit === 'barspoon' ? 'bar spoon' : unit}
                                           </SelectItem>
                                         ))}
                                       </SelectContent>

--- a/server/utils/recipeParser.ts
+++ b/server/utils/recipeParser.ts
@@ -68,7 +68,7 @@ function extractRecipesFromText(text: string): any[] {
       };
     }
     // Ingredient detection (starts with number or fraction)
-    else if (line.match(/^\d+(\.\d+)?\s*(oz|ml|dash|part|cup|tsp|tbsp)/i)) {
+    else if (line.match(/^\d+(\.\d+)?\s*(oz|ml|dash|part|cup|tsp|tbsp|barspoon)/i)) {
       if (currentRecipe) {
         const parts = line.split(/\s+/);
         currentRecipe.ingredients.push({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -120,7 +120,7 @@ export const cocktailIngredients = pgTable("cocktail_ingredients", {
   cocktailId: integer("cocktail_id").notNull().references(() => cocktails.id, { onDelete: "cascade" }),
   ingredientId: integer("ingredient_id").notNull().references(() => ingredients.id, { onDelete: "cascade" }),
   amount: text("amount").notNull(), // e.g., "2", "1.5", "splash"
-  unit: text("unit").notNull(), // oz, ml, parts, dashes, drops, tsp, tbsp, cups, slices, wedges, splash, twist, whole
+  unit: text("unit").notNull(), // oz, ml, parts, dashes, drops, tsp, tbsp, barspoon, cups, slices, wedges, splash, twist, whole
   order: integer("order").default(0).notNull(), // for display order
 });
 

--- a/tests/regression/ai-multi-recipe-parse.test.ts
+++ b/tests/regression/ai-multi-recipe-parse.test.ts
@@ -198,7 +198,7 @@ describe('AI Multi-Recipe Parser with JSON Repair', () => {
       }{
         "recipes": [
           {
-            "name": "Margarita", 
+            "name": "Margarita",
             "ingredients": [{"quantity": "2", "unit": "oz", "item": "Tequila"}],
             "instructions": ["Shake with ice"]
           }
@@ -209,6 +209,13 @@ describe('AI Multi-Recipe Parser with JSON Repair', () => {
       expect(result.recipes).toHaveLength(2);
       expect(result.recipes[0].name).toBe("Old Fashioned");
       expect(result.recipes[1].name).toBe("Margarita");
+    });
+
+    it('should parse text recipes with bar spoon measurements', () => {
+      const text = `Bar Spoon Test\n1 barspoon sugar\nStir`; // plain text input
+      const result = parseRecipesFromAI(text);
+      expect(result.recipes).toHaveLength(1);
+      expect(result.recipes[0].ingredients[0].unit).toBe('barspoon');
     });
 
     it('should normalize "Ingredients:" / "Instructions:" keys', () => {


### PR DESCRIPTION
## Summary
- allow selecting "bar spoon" when adding a cocktail ingredient
- support "bar spoon" unit in recipe importer and parser
- document new unit in schema and add regression test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a9ee42d48330bf23eb799b5db828