### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,17 @@
     <link rel="apple-touch-icon" href="/mixi-bot-192.png" />
   <style>
       @import url("https://fonts.googleapis.com/css?family=Plus+Jakarta+Sans:800,400,500,700");
-    </style></head>
+    </style>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R6KBRB8FWS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R6KBRB8FWS');
+    </script>
+  </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
## Summary
- add Google Analytics gtag snippet to client index.html head

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c16c123d448330990f5b023171fae2